### PR TITLE
Fix: wrapStream crashes with "push after EOF" and hangs with streamx destinations

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,13 +97,9 @@ function wrapStream(original, errorHandler) {
 	});
 
 	original.on("data", (data) => {
-		// Guard: wrapper may already be ended if callNext() advanced the stream
-		// before all data events from a 1-to-N transform have fired.
-		if (!wrapper.readableEnded) {
-			if (!wrapper.push(data)) {
-				// If  the wrapper is full, we need to pause the original stream
-				original.pause();
-			}
+		if (!wrapper.push(data)) {
+			// If  the wrapper is full, we need to pause the original stream
+			original.pause();
 		}
 
 		callNext();

--- a/index.js
+++ b/index.js
@@ -53,19 +53,66 @@ function wrapStream(original, errorHandler) {
 			// this should ensure the backpressure is handled correctly
 			original.write(chunk, encoding);
 		},
+		flush(done) {
+			// Defer to next tick so any pending emitCloseNT (scheduled by destroy()
+			// during error recovery) runs first and fully settles before we call
+			// original.end(). If we acted synchronously here, emitCloseNT would
+			// overwrite our closeEmitted = false reset and block needFinish().
+			process.nextTick(() => {
+				// Propagate end to original and wait for it to fully drain before
+				// closing the wrapper. Two problems are solved here:
+				//
+				// 1. A 1-to-N transform (e.g. gulp.dest() with sourcemaps) emits
+				//    multiple data events per input chunk. callNext() fires after the
+				//    first, which would prematurely close the wrapper before the
+				//    remaining outputs arrive (causing "push after EOF").
+				//
+				// 2. Without calling original.end(), streamx-based destinations
+				//    (vinyl-fs dest) never emit "finish", so pump's end-of-stream
+				//    monitor never fires and the gulp task callback is never called.
+				let finished = false;
+				const finish = () => {
+					if (finished) return;
+					finished = true;
+					original.removeListener("end", finish);
+					original.removeListener("error", finish);
+					done();
+				};
+				// Set up listeners before end() to avoid missing a synchronous end.
+				original.once("end", finish);
+				original.once("error", finish);
+				// After _undestroy() + emitCloseNT, closeEmitted is left as true
+				// which blocks needFinish() and endReadableNT() from running. Reset
+				// it so that end() properly triggers finish and end events.
+				if (original._writableState)
+					original._writableState.closeEmitted = false;
+				if (original._readableState)
+					original._readableState.closeEmitted = false;
+				// resume() re-enters flowing mode in case destroy()/_undestroy()
+				// reset readableState.flowing to null.
+				original.resume();
+				original.end();
+			});
+		},
 	});
 
 	original.on("data", (data) => {
-		// Push data to the wrapper
-		if (!wrapper.push(data)) {
-			// If  the wrapper is full, we need to pause the original stream
-			original.pause();
+		// Guard: wrapper may already be ended if callNext() advanced the stream
+		// before all data events from a 1-to-N transform have fired.
+		if (!wrapper.readableEnded) {
+			if (!wrapper.push(data)) {
+				// If  the wrapper is full, we need to pause the original stream
+				original.pause();
+			}
 		}
 
 		callNext();
 	});
 
-	original.on("end", () => wrapper.push(null));
+	// "end" is intentionally not forwarded here. The _flush handler above
+	// waits for original to emit "end" and then calls done(), after which
+	// Node.js automatically pushes null on wrapper. A manual push(null)
+	// here would throw "push after EOF".
 	original.on("drain", () => wrapper.emit("drain"));
 	original.on("error", (err) => {
 		// Modern stream destroy themselves when an error is thrown

--- a/test/oneToN.test.js
+++ b/test/oneToN.test.js
@@ -1,0 +1,52 @@
+const { Readable, Transform } = require("node:stream");
+const { finished } = require("node:stream/promises");
+const test = require("ava");
+const streamx = require("streamx");
+
+const plumber = require("../");
+const { peek } = require("./util");
+
+// Simulates gulp.dest() with sourcemaps: a streamx-based Transform that emits
+// two chunks per input (e.g. compiled CSS file + .map file)
+function streamxOneToTwoTransform() {
+	return new streamx.Transform({
+		transform(chunk, cb) {
+			this.push(`${chunk}-a`);
+			this.push(`${chunk}-b`);
+			cb();
+		},
+	});
+}
+
+test("1-to-N streamx transform does not cause push-after-EOF", async (t) => {
+	const actual = [];
+
+	const stream = Readable.from([1, 2, 3])
+		.pipe(plumber())
+		.pipe(streamxOneToTwoTransform())
+		.pipe(peek((data) => actual.push(data)));
+
+	stream.on("data", () => {});
+
+	await finished(stream);
+
+	t.deepEqual(actual, ["1-a", "1-b", "2-a", "2-b", "3-a", "3-b"]);
+});
+
+test("pipeline completes when using 1-to-N streamx transform", async (t) => {
+	// Guards against the pipeline hanging forever (original.end() never called)
+	const stream = Readable.from([1, 2, 3])
+		.pipe(plumber())
+		.pipe(streamxOneToTwoTransform());
+
+	stream.on("data", () => {});
+
+	await t.notThrowsAsync(
+		Promise.race([
+			finished(stream),
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error("pipeline did not complete")), 2000),
+			),
+		]),
+	);
+});


### PR DESCRIPTION
## Problem

Two distinct bugs in `wrapStream()` were triggered when this library is used with `gulp.dest({ sourcemaps: '.' })` inside `crafty-runner-gulp`. Both bugs manifested only in **watch mode**, because that is the only path where `plumber`'s `alternatePipe` is active and therefore `wrapStream` is exercised.

### Bug 1 — `ERR_STREAM_PUSH_AFTER_EOF` crash

`gulp.dest()` with sourcemaps uses a streamx-based `Composer` that emits **two** vinyl files for each input file: the compiled output and its `.map` sidecar. The `wrapStream` proxy was not designed for this 1-to-N pattern.

In the `original.on("data", ...)` handler, `callNext()` was called unconditionally after **every** data event. For the first data event on a given input chunk, `callNext()` called the Transform's `next()` callback. In Node.js's Transform implementation, calling `next()` while the writable side has already ended triggers `_flush()`, which calls `push(null)` and marks `wrapper.readableEnded = true`. When the second data event then arrived (the `.map` file from the same input), `wrapper.push(data)` threw `ERR_STREAM_PUSH_AFTER_EOF`.

Streamx queues data events asynchronously via `process.nextTick`, which is why this race condition only appears with streamx-based streams — with synchronous Node.js Transforms the two pushes happen in the same tick and `_flush` cannot interleave.

### Bug 2 — Pipeline hangs forever (gulp task never completes)

`wrapStream` forwarded data from `original` to `wrapper` by calling `original.write(chunk)` for each incoming chunk but **never** called `original.end()`. For streamx-based destinations the end-of-stream signal drives internal machinery:

- vinyl-fs's `Composer` will not emit `finish` until its writable side is explicitly ended.
- `pump` (used internally by `gulp.dest`) monitors the destination's `finish` event via `eos`.
- Without `finish`, `pump`'s completion callback never fires, and the gulp task callback `cb` is never called.

The symptom was that the first run completed correctly, but `crafty watch` would rebuild on file save, the task would run, produce output — and then freeze permanently instead of re-arming the watcher.

Bug 1's crash had been masking Bug 2 in most testing scenarios.

## Root cause in `wrapStream`

```
wrapStream(original, errorHandler)
  └─ wrapper  (Transform — the proxy)
       │  transform(chunk, enc, next): original.write(chunk)
       │  [no flush implementation]
       │
       └─> original  (downstream: gulp.dest / any transform)
             data  → wrapper.push(data); callNext()   ← called on EVERY data event
             end   → wrapper.push(null)               ← manual, broken for 1-to-N
             error → _undestroy(); callNext(); errorHandler()
```

The core problems:
1. `callNext()` (→ `next()`) was called on every `data` event, but for 1-to-N transforms there are multiple data events per input chunk.
2. `original.end()` was never called, so `original` never knew all input had been consumed.

## Fix

All changes are in `wrapStream()` in `index.js`.

### 1. Add a `flush` handler to the wrapper Transform

The `flush(done)` handler is the natural place to propagate end-of-input to `original` and wait for it to drain completely before closing the wrapper. It replaces the deleted `original.on("end", () => wrapper.push(null))` listener — the handler's `done()` callback causes Node.js to push `null` automatically, so a manual `push(null)` is no longer needed (and would throw a second EOF error).

### 2. Defer flush body to `process.nextTick`

When `flush` is called it may be executing synchronously inside Node.js's `emitErrorCloseNT` nextTick callback (triggered by `destroy()` during error recovery). `emitErrorCloseNT` calls `emitErrorNT` (which fires our error handler and ultimately calls the wrapper's `next()`, which triggers `flush`) and then immediately calls `emitCloseNT`, which sets `_writableState.closeEmitted = true`.

`closeEmitted = true` is checked by `needFinish()` and `endReadableNT()` — two internal guards that prevent `finish` and `end` from being emitted. If we call `original.end()` before `emitCloseNT` runs, the `closeEmitted` flag is overwritten to `true` by the time the Node.js event loop tries to emit `finish`, permanently blocking it.

Deferring the entire flush body to `process.nextTick` ensures `emitCloseNT` has already run and set `closeEmitted = true` **before** we reset it and call `original.end()`.

### 3. Reset `closeEmitted` before calling `original.end()`

After `_undestroy()` resets `closeEmitted = false`, `emitCloseNT` immediately sets it back to `true` (as described above). We reset both `_writableState.closeEmitted` and `_readableState.closeEmitted` to `false` inside the deferred body so that `needFinish` and `endReadableNT` can proceed. This only affects Node.js streams that went through `destroy()` + `_undestroy()` during error recovery; streamx streams do not use this flag.

### 4. Add `original.resume()` before `original.end()`

`destroy()` + `_undestroy()` may leave `_readableState.flowing` as `null`. If the stream is not in flowing mode, Node.js will not emit `end` after `push(null)` — it waits for a consumer to call `read()`. Calling `original.resume()` re-enters flowing mode, guaranteeing that the `end` event fires so `done()` is called and the wrapper closes.

## What changed

| Location | Change |
|---|---|
| `wrapStream` — wrapper `Transform` | Added `flush(done)` handler (deferred via `process.nextTick`) |
| `wrapStream` — `original.on("data", ...)` | Added `!wrapper.readableEnded` guard before `wrapper.push()` |
| `wrapStream` — `original.on("end", ...)` | Removed — superseded by `flush`'s `done()` callback |
| `test/oneToN.test.js` | New test file with two regression tests |

## Tests

Two new regression tests in `test/oneToN.test.js` use a **streamx** 1-to-2 Transform (the minimal faithful reproduction of `gulp.dest()` with sourcemaps) piped through `plumber()`:

- **"1-to-N streamx transform does not cause push-after-EOF"** — asserts that all six outputs (`1-a`, `1-b`, `2-a`, `2-b`, `3-a`, `3-b`) arrive without error.
- **"pipeline completes when using 1-to-N streamx transform"** — asserts that `finished()` resolves within 2 seconds, guarding against the hang described in Bug 2.

Both tests were verified to **fail** against the unpatched code before the fix was applied.

All 30 existing tests continue to pass.

